### PR TITLE
Make a single Integer token with metadata

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -82,6 +82,15 @@ pub enum PreprocessorError {
     MoreThanOneElse,
     UnfinishedBlock,
     LineOverflow,
+    NotSupported16BitLiteral,
+    NotSupported64BitLiteral,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Integer {
+    pub value: u64,
+    pub signed: bool,
+    pub width: i32,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -106,8 +115,7 @@ pub struct Pragma {
 pub enum TokenValue {
     Ident(String),
 
-    Int(i32),
-    UInt(u32),
+    Integer(Integer),
     //Float(f32), // TODO
     Punct(Punct),
 


### PR DESCRIPTION
Previously there were two integer tokens, and i32 one
and u32 one. Having the lexer handle integer validation
was going to be a problem in the future, for example for
-2^31 which is a valid i32 but is parse as (-) (2^31)
which has an invalid i32 as the second token.

Instead return an Integer structure that contains a u64
(big enough for all our integers) and metadata on width
and signedness.

Updates all the tests dealing with integers.

Updates line overflow computations to work on u32 instead
of i32.

Fixes a couple clippy warnings in the tests.

Related to #3