### PR TITLE
Add (non-scientific) float parsing

### DIFF
--- a/src/pp.rs
+++ b/src/pp.rs
@@ -52,6 +52,7 @@ trait MELexer {
 fn make_unexpected_error(token: LexerToken) -> StepExit {
     let error = match token.value {
         LexerTokenValue::Integer(i) => PreprocessorError::UnexpectedToken(TokenValue::Integer(i)),
+        LexerTokenValue::Float(f) => PreprocessorError::UnexpectedToken(TokenValue::Float(f)),
         LexerTokenValue::Ident(s) => PreprocessorError::UnexpectedToken(TokenValue::Ident(s)),
         LexerTokenValue::Punct(p) => PreprocessorError::UnexpectedToken(TokenValue::Punct(p)),
         LexerTokenValue::NewLine => PreprocessorError::UnexpectedNewLine,
@@ -86,6 +87,10 @@ pub fn convert_lexer_token(token: LexerToken) -> Result<Token, (PreprocessorErro
     match token.value {
         LexerTokenValue::Integer(i) => Ok(Token {
             value: TokenValue::Integer(i),
+            location,
+        }),
+        LexerTokenValue::Float(f) => Ok(Token {
+            value: TokenValue::Float(f),
             location,
         }),
         LexerTokenValue::Ident(s) => Ok(Token {

--- a/src/token.rs
+++ b/src/token.rs
@@ -64,6 +64,7 @@ pub enum Punct {
 // TODO location?
 pub enum PreprocessorError {
     IntegerOverflow,
+    FloatParsingError,
     UnexpectedCharacter,
     UnexpectedToken(TokenValue),
     UnexpectedHash,
@@ -94,6 +95,12 @@ pub struct Integer {
 }
 
 #[derive(Clone, PartialEq, Debug)]
+pub struct Float {
+    pub value: f32,
+    pub width: i32,
+}
+
+#[derive(Clone, PartialEq, Debug)]
 pub struct Version {
     pub tokens: Vec<Token>,
     pub is_first_directive: bool,
@@ -116,7 +123,7 @@ pub enum TokenValue {
     Ident(String),
 
     Integer(Integer),
-    //Float(f32), // TODO
+    Float(Float),
     Punct(Punct),
 
     Version(Version),


### PR DESCRIPTION
PTAL!

I didn't do scientific floats and broke a corner case of octal numbers because if we need to fix it, I'd rather do it after the `Cow` refactor (I'm still not sure how that one will work).