### PR TITLE
Add support for expressions in the line directive

### DIFF
--- a/src/pp.rs
+++ b/src/pp.rs
@@ -45,6 +45,7 @@ impl<T> From<StepExit> for Step<T> {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 trait MELexer {
     fn step(&mut self) -> Step<Token>;
     fn get_define(&self, name: &str) -> Option<&Rc<Define>>;
@@ -931,7 +932,7 @@ impl MacroProcessor {
             }
         }
 
-        Ok(lexer.step()?)
+        lexer.step()
     }
 
     fn step(&mut self, lexer: &mut dyn MELexer) -> Step<Token> {

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -356,23 +356,29 @@ impl<'a> DirectiveProcessor<'a> {
             return self.consume_until_newline();
         }
 
-        let token = self.expect_a_lexer_token(directive_location)?;
+        let line = self.gather_until_newline()?;
 
-        // TODO support expressions for the line number.
-        // TODO figure out what to do with the file, either number or string?
+        let mut parser = if_parser::IfParser::new(line, &self.defines, directive_location, false);
+        let line = parser.evaluate_expression()?;
 
         // Validates that the line is between 0 and 2^31 as per the C standard.
-        match token.value {
-            LexerTokenValue::Integer(i) => {
-                if i.value >= (1u64 << 32u64) {
-                    return Err(make_line_overflow_error(token.location));
-                }
-                self.line_offset = i.value as i64 - directive_location.line as i64;
-            }
-            _ => return Err(make_unexpected_error(token)),
-        };
+        if line as u64 >= (1 << 32) {
+            return Err(make_line_overflow_error(directive_location));
+        }
+        self.line_offset = line - directive_location.line as i64;
 
-        self.expect_lexer_token(LexerTokenValue::NewLine, token.location)?;
+        if parser.peek()?.is_some() {
+            // TODO figure out what to do with the file, either number or string?
+            let _source_id = parser.evaluate_expression()?;
+        }
+
+        if let Some(token) = parser.peek()? {
+            return Err(StepExit::Error((
+                PreprocessorError::UnexpectedToken(token.value),
+                token.location,
+            )));
+        }
+
         Ok(())
     }
 

--- a/src/pp_tests.rs
+++ b/src/pp_tests.rs
@@ -960,8 +960,9 @@ fn parse_line() {
     check_preprocessed_result(
         "#line 4u
          #line 3
-         #line 0xF00",
-        "",
+         #line 0xF00
+         __LINE__",
+        "0xF01u",
     );
 
     // Test with something other than a number after #line (including a newline)
@@ -976,8 +977,9 @@ fn parse_line() {
     check_preprocessed_result(
         "#if 0
          #line !
-         #endif",
-        "",
+         #endif
+         __LINE__",
+        "4u",
     );
     // Test that #line must have a newline after the integer (this will change when #line
     // supports constant expressions)
@@ -990,9 +992,21 @@ fn parse_line() {
     check_preprocessing_error("#line -1", PreprocessorError::LineOverflow);
 
     // Test some expression
-    check_preprocessed_result("#line 20 << 2 + 1", "");
-    check_preprocessed_result("#line 20 * 0 -2 + 100", "");
-    check_preprocessed_result("#line 0 (1 << 1 * (10)) % 2", "");
+    check_preprocessed_result(
+        "#line 20 << 2 + 1
+         __LINE__",
+        "161u",
+    );
+    check_preprocessed_result(
+        "#line 20 * 0 -2 + 100
+        __LINE__",
+        "99u",
+    );
+    check_preprocessed_result(
+        "#line 0 (1 << 1 * (10)) % 2
+        __LINE__",
+        "1u",
+    );
 }
 
 #[test]

--- a/src/pp_tests.rs
+++ b/src/pp_tests.rs
@@ -965,11 +965,8 @@ fn parse_line() {
     );
 
     // Test with something other than a number after #line (including a newline)
-    check_preprocessing_error(
-        "#line !",
-        PreprocessorError::UnexpectedToken(TokenValue::Punct(Punct::Bang)),
-    );
-    check_preprocessing_error("#line", PreprocessorError::UnexpectedNewLine);
+    check_preprocessing_error("#line !", PreprocessorError::UnexpectedEndOfInput);
+    check_preprocessing_error("#line", PreprocessorError::UnexpectedEndOfInput);
     check_preprocessing_error(
         "#line foo",
         PreprocessorError::UnexpectedToken(TokenValue::Ident("foo".into())),
@@ -986,17 +983,16 @@ fn parse_line() {
     // supports constant expressions)
     check_preprocessing_error("#line 1 #", PreprocessorError::UnexpectedHash);
 
-    // Test that the integer must be non-negative.
-    // TODO enabled once #line supports parsing expressions.
-    // check_preprocessing_error(
-    //     "#line -1",
-    //     PreprocessorError::LineOverflow,
-    // );
-
     // test that the integer must fit in a u32
     check_preprocessing_error("#line 4294967296u", PreprocessorError::LineOverflow);
     // test that the integer must fit in a u32
     check_preprocessed_result("#line 4294967295u", "");
+    check_preprocessing_error("#line -1", PreprocessorError::LineOverflow);
+
+    // Test some expression
+    check_preprocessed_result("#line 20 << 2 + 1", "");
+    check_preprocessed_result("#line 20 * 0 -2 + 100", "");
+    check_preprocessed_result("#line 0 (1 << 1 * (10)) % 2", "");
 }
 
 #[test]


### PR DESCRIPTION
Based on the `IfParser` adds support for parsing the line and source file id as expressions

Also has a very small commit to fix clippy lints in the latest stable has those were making the pipelines have to much noise to be meaningful