### PR TITLE
Simplify location tracking in the lexer.

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -340,7 +340,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn next_char_if(&mut self, predicate: impl Fn(char) -> bool) -> Option<char> {
+    fn next_char_if(&mut self, predicate: impl FnOnce(char) -> bool) -> Option<char> {
         if let Some(c) = self.inner.peek_char() {
             if predicate(c) {
                 return Some(self.inner.next_char()?);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,8 +1,8 @@
 use crate::token::{Float, Integer, Location, PreprocessorError, Punct};
-use std::{iter::Peekable, str::Chars};
+use std::str::Chars;
 use unicode_xid::UnicodeXID;
 
-type CharAndLocation = (char, Location);
+type CharAndLine = (char, u32);
 
 // GLSL ES 3.20 specification section 3.10. Logical Phases of Compilation
 // This iterator implements phases 4 and 5 of the logical phases of compilation:
@@ -17,53 +17,55 @@ type CharAndLocation = (char, Location);
 //
 // It expects that phases 1 to 3 are already done and that valid utf8 is passed in.
 #[derive(Clone)]
-pub struct CharsAndLocation<'a> {
-    chars: Peekable<Chars<'a>>,
-    loc: Location,
+pub struct CharsAndLine<'a> {
+    inner: Chars<'a>,
+    line: u32,
 }
 
-impl<'a> CharsAndLocation<'a> {
+impl<'a> CharsAndLine<'a> {
     pub fn new(input: &'a str) -> Self {
-        CharsAndLocation {
-            chars: input.chars().peekable(),
-            loc: Location::default(),
+        CharsAndLine {
+            inner: input.chars(),
+            line: 1,
         }
+    }
+
+    pub fn get_current_ptr(&self) -> *const u8 {
+        self.inner.as_str().as_bytes().as_ptr()
     }
 }
 
-impl<'a> Iterator for CharsAndLocation<'a> {
-    type Item = CharAndLocation;
+impl<'a> Iterator for CharsAndLine<'a> {
+    type Item = CharAndLine;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let current = self.chars.next()?;
-        self.loc.start = self.loc.end;
-        self.loc.end += current.len_utf8() as u32;
+        let current = self.inner.next()?;
 
         match current {
             '\n' => {
                 // Consume the token but see if we can grab a \r that follows
-                if self.chars.peek() == Some(&'\r') {
-                    self.chars.next();
-                    self.loc.end += 1;
+                let mut peek_inner = self.inner.clone();
+                if peek_inner.next() == Some('\r') {
+                    self.inner = peek_inner;
                 }
 
-                let res = Some(('\n', self.loc));
-                self.loc.line += 1;
+                let res = Some(('\n', self.line));
+                self.line += 1;
                 res
             }
             '\r' => {
                 // Consume the token but see if we can grab a \n that follows
-                if self.chars.peek() == Some(&'\n') {
-                    self.chars.next();
-                    self.loc.end += 1;
+                let mut peek_inner = self.inner.clone();
+                if peek_inner.next() == Some('\n') {
+                    self.inner = peek_inner;
                 }
 
-                let res = Some(('\n', self.loc));
-                self.loc.line += 1;
+                let res = Some(('\n', self.line));
+                self.line += 1;
                 res
             }
 
-            _ => Some((current, self.loc)),
+            _ => Some((current, self.line)),
         }
     }
 }
@@ -76,27 +78,31 @@ impl<'a> Iterator for CharsAndLocation<'a> {
 //     are not removed.
 #[derive(Clone)]
 pub struct SkipBackslashNewline<'a> {
-    inner: CharsAndLocation<'a>,
+    inner: CharsAndLine<'a>,
 }
 
 impl<'a> SkipBackslashNewline<'a> {
     pub fn new(input: &'a str) -> Self {
         SkipBackslashNewline {
-            inner: CharsAndLocation::new(input),
+            inner: CharsAndLine::new(input),
         }
+    }
+
+    pub fn get_current_ptr(&self) -> *const u8 {
+        self.inner.get_current_ptr()
     }
 }
 
 impl<'a> Iterator for SkipBackslashNewline<'a> {
-    type Item = CharAndLocation;
+    type Item = CharAndLine;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut current = self.inner.next()?;
 
         while current.0 == '\\' {
-            let mut save_point = self.inner.clone();
-            if let Some(('\n', _)) = save_point.next() {
-                self.inner = save_point;
+            let mut peek_inner = self.inner.clone();
+            if let Some(('\n', _)) = peek_inner.next() {
+                self.inner = peek_inner;
                 current = self.next()?;
             } else {
                 return Some(current);
@@ -115,7 +121,7 @@ impl<'a> Iterator for SkipBackslashNewline<'a> {
 //      include both the start and end marker.
 #[derive(Clone)]
 pub struct ReplaceComments<'a> {
-    inner: Peekable<SkipBackslashNewline<'a>>,
+    inner: SkipBackslashNewline<'a>,
 }
 
 // The lexer wants to know when whitespace is a comment to know if a comment was ever processed.
@@ -126,53 +132,55 @@ pub const COMMENT_SENTINEL_VALUE: char = '\r';
 impl<'a> ReplaceComments<'a> {
     pub fn new(input: &'a str) -> Self {
         ReplaceComments {
-            inner: SkipBackslashNewline::new(input).peekable(),
+            inner: SkipBackslashNewline::new(input),
         }
+    }
+
+    pub fn get_current_ptr(&self) -> *const u8 {
+        self.inner.get_current_ptr()
     }
 }
 
 impl<'a> Iterator for ReplaceComments<'a> {
-    type Item = CharAndLocation;
+    type Item = CharAndLine;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut current = self.inner.next()?;
+        let current = self.inner.next()?;
 
         if current.0 != '/' {
             debug_assert!(current.0 != COMMENT_SENTINEL_VALUE);
             return Some(current);
         }
 
-        match self.inner.peek() {
+        let mut peek_inner = self.inner.clone();
+        match peek_inner.next() {
+            // The // case, consume until but not including the next \n
             Some(('/', _)) => {
-                current.1.end += 1;
-                self.inner.next();
-
-                while let Some(&(next, loc)) = self.inner.peek() {
+                self.inner = peek_inner.clone();
+                while let Some((next, _)) = peek_inner.next() {
                     if next == '\n' {
-                        current.1.end = loc.start;
                         break;
                     }
-                    current.1.end = loc.end;
-                    self.inner.next();
+                    self.inner = peek_inner.clone();
                 }
 
                 Some((COMMENT_SENTINEL_VALUE, current.1))
             }
+            // The /*, consume until the next */
             Some(('*', _)) => {
-                self.inner.next();
-                current.1.end += 1;
-
                 let mut was_star = false;
-                while let Some((next, loc)) = self.inner.next() {
-                    current.1.end = loc.end;
+                while let Some((next, _)) = peek_inner.next() {
                     if was_star && next == '/' {
                         break;
                     }
                     was_star = next == '*';
                 }
+                self.inner = peek_inner;
 
                 Some((COMMENT_SENTINEL_VALUE, current.1))
             }
+
+            // Not // or /*, do nothing
             _ => Some(current),
         }
     }
@@ -181,6 +189,65 @@ impl<'a> Iterator for ReplaceComments<'a> {
 // A lexer for GLSL tokens that also emits a couple extra tokens that are useful to the
 // preprocessor: # and newlines. It also include metadata for the token for whether it is at the
 // start of the line, or if it has leading whitespace.
+
+// This is a helper iterator to abstract away the tracking of location data (offset, line) from
+// `Lexer`. It looks like a Peekable<Iterator<char>> with `next_char` and `peek_char` but also
+// allows querying the last seen/consumed lines / offset.
+#[derive(Clone)]
+struct LexerCharIterator<'a> {
+    inner: ReplaceComments<'a>,
+    peeked: Option<(CharAndLine, *const u8)>,
+    last_consumed: (CharAndLine, *const u8),
+    input_start: *const u8,
+}
+
+pub const NONE_CONSUMED_SENTINEL_VALUE: char = '\r';
+
+impl<'a> LexerCharIterator<'a> {
+    pub fn new(input: &'a str) -> Self {
+        LexerCharIterator {
+            inner: ReplaceComments::new(input),
+            peeked: None,
+            last_consumed: ((NONE_CONSUMED_SENTINEL_VALUE, 0), input.as_bytes().as_ptr()),
+            input_start: input.as_bytes().as_ptr(),
+        }
+    }
+    fn next_char(&mut self) -> Option<char> {
+        self.last_consumed = match self.peeked.take() {
+            Some(v) => v,
+            None => {
+                let ptr = self.inner.get_current_ptr();
+                (self.inner.next()?, ptr)
+            }
+        };
+        Some(self.last_consumed.0 .0)
+    }
+
+    fn peek_char(&mut self) -> Option<char> {
+        match self.peeked {
+            Some(v) => Some(v.0 .0),
+            None => {
+                let ptr = self.inner.get_current_ptr();
+                let next = self.inner.next()?;
+                self.peeked = Some((next, ptr));
+                Some(next.0)
+            }
+        }
+    }
+
+    fn get_last_seen_line(&self) -> u32 {
+        self.peeked.unwrap_or(self.last_consumed).0 .1
+    }
+
+    fn get_last_seen_start_offset(&self) -> usize {
+        self.peeked.unwrap_or(self.last_consumed).1 as usize - self.input_start as usize
+    }
+
+    fn get_last_consumed_end_offset(&self) -> usize {
+        self.last_consumed.1 as usize - self.input_start as usize
+            + self.last_consumed.0 .0.len_utf8()
+    }
+}
 
 // A superset of the token value returned by the preprocessor
 #[derive(Clone, PartialEq, Debug)]
@@ -212,10 +279,9 @@ pub struct Token {
 
 pub type LexerItem = Result<Token, (PreprocessorError, Location)>;
 pub struct Lexer<'a> {
-    inner: Peekable<ReplaceComments<'a>>,
+    inner: LexerCharIterator<'a>,
     leading_whitespace: bool,
     start_of_line: bool,
-    last_location: Location,
     had_comments: bool,
 }
 
@@ -223,10 +289,9 @@ impl<'a> Lexer<'a> {
     pub fn new(input: &'a str) -> Self {
         // TODO bail out on source that is too large.
         Lexer {
-            inner: ReplaceComments::new(input).peekable(),
+            inner: LexerCharIterator::new(input),
             leading_whitespace: true,
             start_of_line: true,
-            last_location: Location::default(),
             had_comments: false,
         }
     }
@@ -242,10 +307,10 @@ impl<'a> Lexer<'a> {
 
         if self
             .inner
-            .peek()
-            .map_or(false, |c| c.0.is_xid_start() || c.0 == '_')
+            .peek_char()
+            .map_or(false, |c| c.is_xid_start() || c == '_')
         {
-            identifier.push(self.inner.next().unwrap().0);
+            identifier.push(self.inner.next_char().unwrap());
         }
 
         let rest = self.consume_chars(|c| c.is_xid_continue());
@@ -256,10 +321,9 @@ impl<'a> Lexer<'a> {
     }
 
     fn parse_integer_signedness_suffix(&mut self) -> bool {
-        match self.inner.peek() {
-            Some(&('u', loc)) | Some(&('U', loc)) => {
-                self.inner.next();
-                self.last_location.end = loc.end;
+        match self.inner.peek_char() {
+            Some('u') | Some('U') => {
+                self.inner.next_char();
                 false
             }
             _ => true,
@@ -267,20 +331,19 @@ impl<'a> Lexer<'a> {
     }
 
     fn parse_integer_width_suffix(&mut self) -> Result<i32, PreprocessorError> {
-        match self.inner.peek() {
-            Some(('l', _)) | Some(('L', _)) => Err(PreprocessorError::NotSupported64BitLiteral),
-            Some(('s', _)) | Some(('S', _)) => Err(PreprocessorError::NotSupported16BitLiteral),
+        match self.inner.peek_char() {
+            Some('l') | Some('L') => Err(PreprocessorError::NotSupported64BitLiteral),
+            Some('s') | Some('S') => Err(PreprocessorError::NotSupported16BitLiteral),
             _ => Ok(32),
         }
     }
 
     fn parse_float_width_suffix(&mut self) -> Result<i32, PreprocessorError> {
-        match self.inner.peek() {
-            Some(('l', _)) | Some(('L', _)) => Err(PreprocessorError::NotSupported64BitLiteral),
-            Some(('h', _)) | Some(('H', _)) => Err(PreprocessorError::NotSupported16BitLiteral),
-            Some(&('f', loc)) | Some(&('F', loc)) => {
-                self.inner.next();
-                self.last_location.end = loc.end;
+        match self.inner.peek_char() {
+            Some('l') | Some('L') => Err(PreprocessorError::NotSupported64BitLiteral),
+            Some('h') | Some('H') => Err(PreprocessorError::NotSupported16BitLiteral),
+            Some('f') | Some('F') => {
+                self.inner.next_char();
                 Ok(32)
             }
             _ => Ok(32),
@@ -290,10 +353,9 @@ impl<'a> Lexer<'a> {
     fn consume_chars(&mut self, filter: impl Fn(char) -> bool) -> String {
         let mut result: String = Default::default();
 
-        while let Some(&(current, loc)) = self.inner.peek() {
+        while let Some(current) = self.inner.peek_char() {
             if filter(current) {
-                self.inner.next();
-                self.last_location.end = loc.end;
+                self.inner.next_char();
                 result.push(current);
             } else {
                 break;
@@ -311,10 +373,9 @@ impl<'a> Lexer<'a> {
 
         // Handle hexadecimal numbers that needs to consume a..f in addition to digits.
         if first_char == '0' {
-            match self.inner.peek() {
-                Some(&('x', loc)) | Some(&('X', loc)) => {
-                    self.inner.next();
-                    self.last_location.end = loc.end;
+            match self.inner.peek_char() {
+                Some('x') | Some('X') => {
+                    self.inner.next_char();
 
                     raw += &self.consume_chars(|c| matches!(c, '0'..='9' | 'a'..='f' | 'A'..='F'));
                     integer_radix = 16;
@@ -323,7 +384,7 @@ impl<'a> Lexer<'a> {
                 // Octal numbers can also be the prefix of floats, so we need to parse all digits
                 // and not just 0..7 in case it is a float like 00009.0f, the parsing of all digits
                 // is done below, but we still need to remember the radix.
-                Some(('0'..='9', _)) => {
+                Some('0'..='9') => {
                     integer_radix = 8;
                 }
                 _ => {}
@@ -336,9 +397,8 @@ impl<'a> Lexer<'a> {
             // Parse any digits at the end of integers, or for the non-fractional part of floats.
             raw += &self.consume_chars(|c| ('0'..='9').contains(&c));
 
-            if let Some(&('.', loc)) = self.inner.peek() {
-                self.inner.next();
-                self.last_location.end = loc.end;
+            if let Some('.') = self.inner.peek_char() {
+                self.inner.next_char();
                 raw.push('.');
                 is_float = true;
             }
@@ -354,19 +414,19 @@ impl<'a> Lexer<'a> {
         // an integer that could turn into a float if we add a exponent to it (so 0x1E-1
         // isn't recognized as a float).
         if (is_float || integer_radix == 8 || integer_radix == 10)
-            && matches!(self.inner.peek(), Some(('e', _)) | Some(('E', _)))
+            && matches!(self.inner.peek_char(), Some('e') | Some('E'))
         {
-            self.inner.next();
+            self.inner.next_char();
             raw.push('e');
             is_float = true;
 
-            match self.inner.peek() {
-                Some(('+', _)) => {
-                    self.inner.next();
+            match self.inner.peek_char() {
+                Some('+') => {
+                    self.inner.next_char();
                     raw.push('+');
                 }
-                Some(('-', _)) => {
-                    self.inner.next();
+                Some('-') => {
+                    self.inner.next_char();
                     raw.push('-');
                 }
                 _ => {}
@@ -407,9 +467,9 @@ impl<'a> Lexer<'a> {
     fn parse_punctuation(&mut self) -> Result<TokenValue, PreprocessorError> {
         let save_point = self.inner.clone();
 
-        let char0 = self.inner.next().map(|(c, _)| c).unwrap_or('\0');
-        let char1 = self.inner.next().map(|(c, _)| c).unwrap_or('\0');
-        let char2 = self.inner.next().map(|(c, _)| c).unwrap_or('\0');
+        let char0 = self.inner.next_char().unwrap_or('\0');
+        let char1 = self.inner.next_char().unwrap_or('\0');
+        let char2 = self.inner.next_char().unwrap_or('\0');
 
         let maybe_punct = match (char0, char1, char2) {
             ('<', '<', '=') => Some((Punct::LeftShiftAssign, 3)),
@@ -474,13 +534,12 @@ impl<'a> Lexer<'a> {
         if let Some((punct, size)) = maybe_punct {
             self.inner = save_point;
             for _ in 0..size {
-                self.inner.next();
+                self.inner.next_char();
             }
-            self.last_location.end += size - 1;
             Ok(punct.into())
         } else if char0 == '#' {
             self.inner = save_point;
-            self.inner.next();
+            self.inner.next_char();
             Ok(TokenValue::Hash)
         } else {
             Err(PreprocessorError::UnexpectedCharacter)
@@ -492,14 +551,18 @@ impl<'a> Iterator for Lexer<'a> {
     type Item = LexerItem;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(&(current_char, current_loc)) = self.inner.peek() {
+        while let Some(current_char) = self.inner.peek_char() {
             let had_leading_whitespace = self.leading_whitespace;
             self.leading_whitespace = false;
 
+            let mut location = Location {
+                line: self.inner.get_last_seen_line(),
+                start: self.inner.get_last_seen_start_offset() as u32,
+                end: 0,
+            };
+
             let was_start_of_line = self.start_of_line;
             self.start_of_line = false;
-
-            self.last_location = current_loc;
 
             let value = match current_char {
                 ' ' | '\t' | '\x0b' | '\x0c' | COMMENT_SENTINEL_VALUE => {
@@ -508,27 +571,27 @@ impl<'a> Iterator for Lexer<'a> {
                     }
                     self.start_of_line = was_start_of_line;
                     self.leading_whitespace = true;
-                    self.inner.next();
+                    self.inner.next_char();
                     continue;
                 }
                 '\n' => {
                     self.leading_whitespace = true;
                     self.start_of_line = true;
-                    self.inner.next();
+                    self.inner.next_char();
                     Ok(TokenValue::NewLine)
                 }
 
                 c @ '0'..='9' => {
-                    self.inner.next();
+                    self.inner.next_char();
                     self.parse_number(c)
                 }
 
                 // Special case . as a punctuation because it can be the start of a float.
                 '.' => {
-                    self.inner.next();
+                    self.inner.next_char();
 
-                    match self.inner.peek() {
-                        Some(('0'..='9', _)) => self.parse_number('.'),
+                    match self.inner.peek_char() {
+                        Some('0'..='9') => self.parse_number('.'),
                         _ => Ok(TokenValue::Punct(Punct::Dot)),
                     }
                 }
@@ -542,9 +605,11 @@ impl<'a> Iterator for Lexer<'a> {
                 }
             };
 
-            return Some(value.map_err(|e| (e, current_loc)).map(|t| Token {
+            location.end = self.inner.get_last_consumed_end_offset() as u32;
+
+            return Some(value.map_err(|e| (e, Default::default())).map(|t| Token {
                 value: t,
-                location: self.last_location,
+                location,
                 leading_whitespace: had_leading_whitespace,
                 start_of_line: was_start_of_line,
             }));
@@ -553,11 +618,16 @@ impl<'a> Iterator for Lexer<'a> {
         // Do the C hack of always ending with a newline so that preprocessor directives are ended.
         if !self.start_of_line {
             self.start_of_line = true;
-            self.last_location.start = self.last_location.end;
+
+            let end_offset = self.inner.get_last_consumed_end_offset() as u32;
 
             Some(Ok(Token {
                 value: TokenValue::NewLine,
-                location: self.last_location,
+                location: Location {
+                    line: self.inner.get_last_seen_line(),
+                    start: end_offset,
+                    end: end_offset,
+                },
                 leading_whitespace: self.leading_whitespace,
                 start_of_line: false,
             }))

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -317,7 +317,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn parse_integer_signedness_suffix(&mut self) -> bool {
-        !self.next_char_if(|c| c == 'u' || c == 'U').is_some()
+        self.next_char_if(|c| c == 'u' || c == 'U').is_none()
     }
 
     fn parse_integer_width_suffix(&mut self) -> Result<i32, PreprocessorError> {
@@ -343,7 +343,7 @@ impl<'a> Lexer<'a> {
     fn next_char_if(&mut self, predicate: impl FnOnce(char) -> bool) -> Option<char> {
         if let Some(c) = self.inner.peek_char() {
             if predicate(c) {
-                return Some(self.inner.next_char()?);
+                return self.inner.next_char();
             }
         }
         None


### PR DESCRIPTION
This commit changes the location tracking in lexer.rs to be almost
completely implicit, except for line tracking. The offset can be
computed from the start of the &str and the current position of the
innermost iterator. The final location information is only created in
Lexer::next, at the start and the end of the currently build token.

To simplify the control flow for each char consumed, inner iterators
are changed to not use Peekable but instead do copies of inner iterators
as needed.