### PR TITLE
Make Integer/Float tokens be strings instead of parsed numbers

### DIFF
--- a/src/pp.rs
+++ b/src/pp.rs
@@ -360,7 +360,7 @@ impl<'a> DirectiveProcessor<'a> {
         let line = self.gather_until_newline()?;
 
         let mut parser = if_parser::IfParser::new(line, &self.defines, directive_location, false);
-        let line = dbg!(parser.evaluate_expression())?;
+        let line = parser.evaluate_expression()?;
 
         // Validates that the line is between 0 and 2^31 as per the C standard.
         if line as u64 >= (1 << 32) {
@@ -954,7 +954,7 @@ impl MacroProcessor {
 
                 return Ok(Token {
                     value: TokenValue::Integer(
-                        (lexer.apply_line_offset(line, token.location)? as u64).to_string(),
+                        lexer.apply_line_offset(line, token.location)?.to_string(),
                     ),
                     location: token.location,
                 });

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -360,7 +360,7 @@ impl<'a> DirectiveProcessor<'a> {
         let line = self.gather_until_newline()?;
 
         let mut parser = if_parser::IfParser::new(line, &self.defines, directive_location, false);
-        let line = parser.evaluate_expression()?;
+        let line = dbg!(parser.evaluate_expression())?;
 
         // Validates that the line is between 0 and 2^31 as per the C standard.
         if line as u64 >= (1 << 32) {
@@ -953,11 +953,9 @@ impl MacroProcessor {
                 };
 
                 return Ok(Token {
-                    value: TokenValue::Integer(Integer {
-                        value: lexer.apply_line_offset(line, token.location)? as u64,
-                        signed: false,
-                        width: 32,
-                    }),
+                    value: TokenValue::Integer(
+                        (lexer.apply_line_offset(line, token.location)? as u64).to_string(),
+                    ),
                     location: token.location,
                 });
             }


### PR DESCRIPTION
This will help move tokens to contain CoW strings in the future to
reduce the number of memory allocations done by the preprocessor.

Detailed changes are:
 - Change the TokenValue to use strings for Integers and Floats
 - Move logic to parse integers and floats in token.rs as functions
   taking an &str and returning parsed numbers.
 - Rework the lexer tests for this new representation.
 - Simplify lexer tests by making most tests use the following pattern
   `assert_eq!(lexed_token_values("..."), vec![...])` which is less
   noisy.
 - Adapt preprocessor tests to not use unsigned integers for the
   result of the __LINE__ define.

Fixes #3