### PR TITLE
Make crate no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ license = "BSD-3-Clause"
 
 [dependencies]
 unicode-xid = "0.2"
+hashbrown = "0.15.2"

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,5 +1,6 @@
 use crate::token::{Location, PreprocessorError, Punct};
-use std::str::Chars;
+use alloc::string::String;
+use core::str::Chars;
 use unicode_xid::UnicodeXID;
 
 type CharAndLine = (char, u32);

--- a/src/lexer_tests.rs
+++ b/src/lexer_tests.rs
@@ -3,7 +3,10 @@ use super::lexer::{
     COMMENT_SENTINEL_VALUE,
 };
 use super::token::{Location, PreprocessorError, Punct};
-use std::ops::Range;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ops::Range;
 
 fn c(c: char, line: u32) -> Option<(char, u32)> {
     Some((c, line))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+extern crate hashbrown;
 extern crate unicode_xid;
 
 #[allow(clippy::match_like_matches_macro)]

--- a/src/pp.rs
+++ b/src/pp.rs
@@ -1,11 +1,11 @@
 use crate::lexer::{self, Token as LexerToken, TokenValue as LexerTokenValue};
 use crate::token::*;
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, HashSet},
-    convert::TryFrom,
-    rc::Rc,
-};
+use alloc::rc::Rc;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::{cmp::Ordering, convert::TryFrom};
+use hashbrown::{HashMap, HashSet};
 
 mod if_parser;
 
@@ -694,7 +694,7 @@ impl MacroProcessor {
 
                 parameters: Default::default(),
                 parameter_position: 0,
-                parameter_expanding: std::usize::MAX,
+                parameter_expanding: usize::MAX,
             };
 
             // If this is a not a function-like define, __LINE__ inside the define is the line of the first
@@ -911,7 +911,7 @@ impl MacroProcessor {
                     invocation.parameter_position += 1;
                     return Ok(token.clone());
                 } else {
-                    invocation.parameter_expanding = std::usize::MAX;
+                    invocation.parameter_expanding = usize::MAX;
                     return Continue.into();
                 }
             }

--- a/src/pp/if_parser.rs
+++ b/src/pp/if_parser.rs
@@ -1,7 +1,11 @@
 use crate::token::{parse_integer, PreprocessorError, Punct};
 
 use super::{Define, Location, MacroProcessor, MeLexer, Step, StepExit, Token, TokenValue};
-use std::{collections::HashMap, convert::TryInto, rc::Rc, vec};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use alloc::{rc::Rc, vec};
+use core::convert::TryInto;
+use hashbrown::HashMap;
 
 struct IfLexer<'macros> {
     tokens: vec::IntoIter<Token>,

--- a/src/pp_tests.rs
+++ b/src/pp_tests.rs
@@ -1,6 +1,8 @@
 use super::lexer::{self, Token as LexerToken, TokenValue as LexerTokenValue};
 use super::pp::{convert_lexer_token, Preprocessor, PreprocessorItem};
 use super::token::{Location, PreprocessorError, Punct, Token, TokenValue};
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
 struct NoopPreprocessor<'a> {
     lexer: lexer::Lexer<'a>,

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,3 +1,6 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+
 //TODO: Source file
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Location {


### PR DESCRIPTION
The only thing it needs from std is hashmap, but since that's not exposed in the public API we can just use hashbrown for no practical difference.
This allows the crate to be used as a dependency on no_std environments (ie `wasm32v1-none`)