### PR TITLE
Remove Unnecessary `hashbrown` Features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ keywords = ["shader", "preprocessor", "glsl"]
 license = "BSD-3-Clause"
 
 [dependencies]
-hashbrown = "0.15.2"
+hashbrown = { version = "0.15.2", default-features = false, features = ["default-hasher"] }
 unicode-ident = "1.0"


### PR DESCRIPTION
# Objective

As a part of improving [`no_std` support in `wgpu`](https://github.com/gfx-rs/wgpu/issues/6826), I've noticed that `pp-rs` enables features of `hashbrown` it doesn't strictly need. Since you can't disable features enabled in another crate, it'd be nice to keep the features used to a minimum.

## Solution

- Disabled default features on `hashbrown` and re-enabled `default-hasher` (the only required feature)